### PR TITLE
feat: adjust ItemPosition

### DIFF
--- a/harmonytypes/v1/types.proto
+++ b/harmonytypes/v1/types.proto
@@ -67,25 +67,16 @@ message Empty { }
 
 // An object representing an item position between two other items.
 message ItemPosition {
-  // An object that represents the top of an ordered list.
-  message Top { }
-  // An object that represents a place between two items in an ordered list.
-  message Between {
-    // The ID of the previous item.
-    uint64 previous_id = 1;
-    // The ID of the next item.
-    uint64 next_id = 2;
+  // The position
+  enum Position {
+    // The position is before the item
+  	POSITION_BEFORE_UNSPECIFIED = 0;
+  	// The position is after the item
+  	POSITION_AFTER = 1;
   }
-  // An object that represents the bottom of an ordered list.
-  message Bottom { }
 
-  // Position of this item.
-  oneof position {
-    // The item is at the top.
-    Top top = 1;
-    // The item is in between two other items.
-    Between between = 2;
-    // The item is at the bottom.
-    Bottom bottom = 3;
-  }
+  // The ID of the item the position is relative to
+  uint64 item_id = 1;
+  // Whether the position is before or after the given ID
+  Position position = 2;
 }


### PR DESCRIPTION
Due to channel visibility, Top/Between/Bottom doesn't work in a lot of cases.

For example, the list of channels might be:
- a
- b
- c
- d

While a client may see only:
- c
- d

A user moving d above c in the client will result in a Top message, which results in the following from the client's perspective:
- d
- c

The problem is, this results in this ordering for clients that can see all the channels:
- d
- a
- b
- c

The expected result would be
- a
- b
- d
- c

Likewise, Between also poses issues due to channel visibility.

Given a channel list:
- b
- c
- d
- dd
- e

A client might see:
- b
- c
- e

If the client tries to place a channel in between c and e, it looks good from their side, but from the server's perspective, this is invalid, due to c and e not being adjacent.

Using Before/After positioning allows these issues to be avoided, and better matches user expectations.