### PR TITLE
make user_avatar and guild picture optional

### DIFF
--- a/chat/v1/guilds.proto
+++ b/chat/v1/guilds.proto
@@ -11,7 +11,7 @@ message Guild {
   // The name of the guild.
   string name = 1;
   // The picture HMC of the guild.
-  string picture = 2;
+  optional string picture = 2;
   // User ID of the owner of the guild.
   uint64 owner_id = 3;
   // Metadata of the guild.
@@ -52,7 +52,7 @@ enum LeaveReason {
   LEAVE_REASON_KICKED = 2;
 }
 
-// Request type used in `CreateGuild` RPC. 
+// Request type used in `CreateGuild` RPC.
 message CreateGuildRequest {
   // The name of the guild.
   string name = 1;

--- a/profile/v1/types.proto
+++ b/profile/v1/types.proto
@@ -23,7 +23,7 @@ message Profile {
   // the name of the user.
   string user_name = 1;
   // the user's avatar.
-  string user_avatar = 2;
+  optional string user_avatar = 2;
   // the status of the user.
   UserStatus user_status = 3;
   // whether the user is a bot or not.


### PR DESCRIPTION
This saves on network usage by being able to know whether a picture is set beforehand.