### PR TITLE
make server subscribe clients to all events by default

### DIFF
--- a/chat/v1/chat.proto
+++ b/chat/v1/chat.proto
@@ -17,12 +17,12 @@ service ChatService {
   rpc CreateGuild(CreateGuildRequest) returns (CreateGuildResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
   }
-  
+
   // Endpoint to create a "room" guild.
   rpc CreateRoom(CreateRoomRequest) returns (CreateRoomResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
   }
-  
+
   // Endpoint to create a "direct message" guild.
   //
   // - The inviter and the invitee that join the created guild will both be owners.
@@ -37,7 +37,7 @@ service ChatService {
   rpc CreateDirectMessage(CreateDirectMessageRequest) returns (CreateDirectMessageResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
   }
-  
+
   // Endpoint to upgrade a "room" guild to a "normal" guild.
   rpc UpgradeRoomToGuild(UpgradeRoomToGuildRequest) returns (UpgradeRoomToGuildResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
@@ -62,7 +62,7 @@ service ChatService {
   rpc GetGuildList(GetGuildListRequest) returns (GetGuildListResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
   }
-  
+
   // Endpoint to invite a user to a guild.
   rpc InviteUserToGuild(InviteUserToGuildRequest) returns (InviteUserToGuildResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
@@ -88,7 +88,7 @@ service ChatService {
   rpc RejectPendingInvite(RejectPendingInviteRequest) returns (RejectPendingInviteResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
   }
-  
+
   // Endpoint to ignore (delete without notification to the inviter) an
   // invite from your pending invite list.
   rpc IgnorePendingInvite(IgnorePendingInviteRequest) returns (IgnorePendingInviteResponse) {
@@ -378,6 +378,9 @@ service ChatService {
   }
 
   // Endpoint to stream events from the homeserver.
+  // By default, this endpoint will subscribe to all events.
+  // Any guilds joined in the future will be added to the subscription as well.
+  // Use the UnsubscribeFromAll event for unsubscribing from all current subscriptions and disable the automatic guild subscriptions
   rpc StreamEvents(stream StreamEventsRequest) returns (stream StreamEventsResponse) {
     option (harmonytypes.v1.metadata).requires_authentication = true;
   }

--- a/chat/v1/stream.proto
+++ b/chat/v1/stream.proto
@@ -13,6 +13,9 @@ import "profile/v1/stream.proto";
 option go_package = "github.com/harmony-development/legato/gen/chat/v1";
 
 // Request type for use in the `StreamEvents` endpoint.
+// By default, this endpoint will subscribe to all events.
+// Any guilds joined in the future will be added to the subscription as well.
+// Use the UnsubscribeFromAll event for unsubscribing from all current subscriptions and disable the automatic guild subscriptions
 message StreamEventsRequest {
   // Event source for guilds' events.
   message SubscribeToGuild {
@@ -23,6 +26,8 @@ message StreamEventsRequest {
   message SubscribeToActions {}
   // Event source for homeserver events.
   message SubscribeToHomeserverEvents {}
+  // Event to unsubscribe from all events.
+  message UnsubscribeFromAll {}
 
   // Describes which event source to subscribe to.
   oneof request {
@@ -32,6 +37,8 @@ message StreamEventsRequest {
     SubscribeToActions subscribe_to_actions = 2;
     // Subscribe to the homeserver event source.
     SubscribeToHomeserverEvents subscribe_to_homeserver_events = 3;
+    // Unsubscribe from all events.
+    UnsubscribeFromAll unsubscribe_from_all = 4;
   }
 }
 
@@ -110,7 +117,7 @@ message StreamEvent {
     uint64 guild_id = 1;
     // Channel ID of the channel that was changed.
     uint64 channel_id = 2;
-    // The new name of the channel. 
+    // The new name of the channel.
     optional string new_name = 3;
     // The new metadata of the channel.
     optional harmonytypes.v1.Metadata new_metadata = 4;


### PR DESCRIPTION
most clients would want to subscribe to all events anyway. Clients should explicitly unsubscribe from all events if they want more granular control.