### PR TITLE
feat(mediaproxy): include size of the file in media

### DIFF
--- a/stable/mediaproxy/v1/mediaproxy.proto
+++ b/stable/mediaproxy/v1/mediaproxy.proto
@@ -26,6 +26,12 @@ message MediaMetadata {
   string mimetype = 1;
   // Filename of the media.
   string filename = 2;
+  // Sıze of the media.
+  //
+  // This should (usually) be the size taken from the `Content-Length` header
+  // (for HTTP requests).
+  // If this is not included, then it means the size could not be determined.
+  optional uint32 size = 3;
 }
 
 // Used in the `FetchLinkMetadata` endpoint.


### PR DESCRIPTION
This is important for clients to decide whether or not they should actually fetch the media (eg. if it's a small image, fetch it automatically).